### PR TITLE
Modified beginner Yaku to be bold, italic, and smallcaps

### DIFF
--- a/includes/yaku-honours.tex
+++ b/includes/yaku-honours.tex
@@ -1,6 +1,6 @@
 \subsection*{Honours}
 \begin{yakutable}
-  \hline \yaku{\textbf{Yakuhai}}{役牌}{Set of dragons or round/seat winds}{1}{1}{Each set is counted}\\
+  \hline \yaku{\textbf{\textit{Yakuhai}}}{役牌}{Set of dragons or round/seat winds}{1}{1}{Each set is counted}\\
   \hline \yaku{Honroutou}{混老頭}{Only terminals and honours}{2}{2}{}\\
   \hline \yaku{Shousangen}{小三元}{Two sets and a pair of dragons}{2}{2}{Sets count for yakuhai also}\\
   \hline \yaku{Daisangen}{大三元}{Three sets of dragons}{Y}{Y}{}\\

--- a/includes/yaku-legend.tex
+++ b/includes/yaku-legend.tex
@@ -2,7 +2,7 @@
 \hfill\textbf{\uppercase{Legend}}%
 \hfill%
 \hfill\begin{tabular}{|l|c:c|}\hline\textsc{Yaku}$\qquad$&Closed&Open\\\hline\end{tabular}%
-\hfill\textbf{\textsc{Beginner-Friendly}}%
+\hfill\textit{\textbf{\textsc{Beginner-Friendly}}}%
 \hfill\textbf{M}\quad Mangan%
 \hfill\textbf{Y}\quad Yakuman%
 \hfill\hfill%

--- a/includes/yaku-legend.tex
+++ b/includes/yaku-legend.tex
@@ -2,7 +2,7 @@
 \hfill\textbf{\uppercase{Legend}}%
 \hfill%
 \hfill\begin{tabular}{|l|c:c|}\hline\textsc{Yaku}$\qquad$&Closed&Open\\\hline\end{tabular}%
-\hfill\textit{\textbf{\textsc{Beginner-Friendly}}}%
+\hfill\textbf{\textit{\textsc{Beginner-Friendly}}}%
 \hfill\textbf{M}\quad Mangan%
 \hfill\textbf{Y}\quad Yakuman%
 \hfill\hfill%

--- a/includes/yaku-sequences.tex
+++ b/includes/yaku-sequences.tex
@@ -1,8 +1,8 @@
 \subsection*{Sequences}
 \begin{yakutable}
-  \hline \yaku{\textbf{Pinfu}}{平和}{Only sequences, 2-sided wait, pair is not yakuhai tiles}{1}{$-$}{}\\
+  \hline \yaku{\textbf{\textit{Pinfu}}}{平和}{Only sequences, 2-sided wait, pair is not yakuhai tiles}{1}{$-$}{}\\
   \hline \yaku{Iipeikou}{一盃口}{Two identical sequences}{1}{$-$}{}\\
-  \hline \yaku{\textbf{Sanshoku}}{三色同順}{Same sequence in each suit}{2}{1}{}\\
+  \hline \yaku{\textbf{\textit{Sanshoku}}}{三色同順}{Same sequence in each suit}{2}{1}{}\\
   \hline \yaku{Ittsuu}{一気通貫}{Sequences 123, 456, 789 in one suit}{2}{1}{}\\
   \hline \yaku{Ryanpeikou}{二盃口}{Two pairs of identical sequences}{3}{$-$}{}\\
   \hline

--- a/includes/yaku-sets.tex
+++ b/includes/yaku-sets.tex
@@ -1,6 +1,6 @@
 \subsection*{Sets}
 \begin{yakutable}
-  \hline \yaku{\textbf{Toitoi}}{対々和}{Only sets}{2}{2}{}\\
+  \hline \yaku{\textbf{\textit{Toitoi}}}{対々和}{Only sets}{2}{2}{}\\
   \hline \yaku{Sanankou}{三暗刻}{Three concealed sets}{2}{2}{}\\
   \hline \yaku{Sanshoku Doukou}{三色同刻}{Same set in each suit}{2}{2}{}\\
   \hline \yaku{Sankantsu}{三槓子}{Three kans}{2}{2}{}\\

--- a/includes/yaku-situational.tex
+++ b/includes/yaku-situational.tex
@@ -1,9 +1,9 @@
 \subsection*{Situational}
 \begin{yakutable}
-  \hline \yaku{\textbf{Riichi}}{立直}{Declare riichi}{1}{$-$}{}\\
+  \hline \yaku{\textbf{\textit{Riichi}}}{立直}{Declare riichi}{1}{$-$}{}\\
   \hline \yaku{Ippatsu}{一発}{Win within 1 turn of riichi}{1}{$-$}{Uninterrupted, Add to riichi}\\
   \hline \yaku{Double Riichi}{ダブル立直}{First-turn riichi}{1}{$-$}{Unint., Add to riichi}\\
-  \hline \yaku{\textbf{Menzen Tsumo}}{門前清自摸和}{Closed-hand tsumo}{1}{$-$}{}\\
+  \hline \yaku{\textbf{\textit{Menzen Tsumo}}}{門前清自摸和}{Closed-hand tsumo}{1}{$-$}{}\\
   \hline \yaku{Haitei Raoyue}{海底撈月}{Tsumo on last draw from live wall}{1}{1}{}\\
   \hline \yaku{Houtei Raoyui}{河底撈魚}{Ron on last discard}{1}{1}{}\\
   \hline \yaku{Rinshan Kaihou}{嶺上開花}{Tsumo after a kan}{1}{1}{}\\

--- a/includes/yaku-special.tex
+++ b/includes/yaku-special.tex
@@ -1,6 +1,6 @@
 \subsection*{Special}
 \begin{yakutable}
-  \hline \yaku{\textbf{Chiitoi}}{七対子}{Seven unique pairs}{2}{$-$}{}\\
+  \hline \yaku{\textbf{\textit{Chiitoi}}}{七対子}{Seven unique pairs}{2}{$-$}{}\\
   \ifnagashimangan \hline \yaku{Nagashi Mangan}{流し満貫}{All discards are unclaimed and terminals/honours only}{M}{$-$}{Exhaustive draw}\\\else\fi
   \hline \yaku{Kokushi Musou}{国士無双}{Each terminal and honour plus duplicate}{Y}{$-$}{}\\
   \hline

--- a/includes/yaku-suits.tex
+++ b/includes/yaku-suits.tex
@@ -1,6 +1,6 @@
 \subsection*{Suits}
 \begin{yakutable}
-  \hline \yaku{\textbf{Honitsu}}{混一色}{Single suit with honours}{3}{2}{}\\
+  \hline \yaku{\textbf{\textit{Honitsu}}}{混一色}{Single suit with honours}{3}{2}{}\\
   \hline \yaku{Chinitsu}{清一色}{Single suit, no honours}{6}{5}{}\\
   \hline \yaku{Chuuren Poutou}{九連宝燈}{1112345678999 plus duplicate, single suit}{Y}{$-$}{}\\
   \hline \yaku{Ryuuiisou}{緑一色}{Only green tiles (2/3/4/6/8 sou or hatsu)}{Y}{Y}{}\\

--- a/includes/yaku-terminals.tex
+++ b/includes/yaku-terminals.tex
@@ -1,6 +1,6 @@
 \subsection*{Terminals}
 \begin{yakutable}
-  \hline \yaku{\textbf{Tanyao}}{断幺九}{No terminals or honours}{1}{1}{}\\
+  \hline \yaku{\textbf{\textit{Tanyao}}}{断幺九}{No terminals or honours}{1}{1}{}\\
   \hline \yaku{Chanta}{混全帯么九}{A terminal/honour in each group/pair}{2}{1}{}\\
   \hline \yaku{Junchan}{純全帯么九}{A terminal in each group/pair, no honours}{3}{2}{}\\
   \hline \yaku{Chinroutou}{清老頭}{Only terminals}{Y}{Y}{}\\


### PR DESCRIPTION
This pull request was made to help beginners discern the difference between the Beginner-Friendly yaku from the rest of the Yaku. The bold on its own was not found to be enough to easily see what's what, so italics seemed like an addition enough to make it work. Having tested italic smallcaps, it felt worse overall as a look than the bold italic smallcaps.