### PR TITLE
Disambiguate wording on Shousuushi and Shousangen

### DIFF
--- a/includes/yaku-honours.tex
+++ b/includes/yaku-honours.tex
@@ -2,9 +2,9 @@
 \begin{yakutable}
   \hline \yaku{\textbf{\textit{Yakuhai}}}{役牌}{Set of dragons or round/seat winds}{1}{1}{Each set is counted}\\
   \hline \yaku{Honroutou}{混老頭}{Only terminals and honours}{2}{2}{}\\
-  \hline \yaku{Shousangen}{小三元}{Two sets and a pair of dragons}{2}{2}{Sets count for yakuhai also}\\
+  \hline \yaku{Shousangen}{小三元}{Two sets of dragons and a pair of the third}{2}{2}{Sets count for yakuhai also}\\
   \hline \yaku{Daisangen}{大三元}{Three sets of dragons}{Y}{Y}{}\\
-  \hline \yaku{Shousuushi}{小四喜}{Three sets and a pair of winds}{Y}{Y}{}\\
+  \hline \yaku{Shousuushi}{小四喜}{Three sets of winds and a pair of the fourth}{Y}{Y}{}\\
   \hline \yaku{Daisuushi}{大四喜}{Four sets of winds}{Y}{Y}{}\\
   \hline \yaku{Tsuuiisou}{字一色}{Only honours}{Y}{Y}{}\\
   \hline


### PR DESCRIPTION
The old wording implied that 南南南、北北北、中中 meets the criteria for Shousangen. Same applies for Shousuushi.