### PR TITLE
Duplicate first tile for dora sequence

### DIFF
--- a/includes/tiles.tex
+++ b/includes/tiles.tex
@@ -3,7 +3,6 @@
 
   \begin{tabular}{ccccccccccccccccccc}
     % pinzu
-    $\hookrightarrow$ &
     \describetile{pin1}{1 pin}{iipin} &
     $\Rightarrow$ &
     \describetile{pin2}{2 pin}{ryanpin} &
@@ -21,10 +20,10 @@
     \describetile{pin8}{8 pin}{paapin} &
     $\Rightarrow$ &
     \describetile{pin9}{9 pin}{kyuupin} &
-    $\rightarrow$\\[2ex]
+    $\rightarrow$ &
+    \tile{pin1}\\[2ex]
 
     % souzu
-    $\hookrightarrow$ &
     \describetile{sou1}{1 sou}{iisou} &
     $\Rightarrow$ &
     \describetile{sou2}{2 sou}{ryansou} &
@@ -42,10 +41,10 @@
     \describetile{sou8}{8 sou}{paasou} &
     $\Rightarrow$ &
     \describetile{sou9}{9 sou}{kyuusou} &
-    $\rightarrow$\\[2ex]
+    $\rightarrow$ &
+    \tile{sou1}\\[2ex]
 
     % manzu
-    $\hookrightarrow$ &
     \describetile{man1}{1 man}{iiwan} &
     $\Rightarrow$ &
     \describetile{man2}{2 man}{ryanwan} &
@@ -63,10 +62,10 @@
     \describetile{man8}{8 man}{paawan} &
     $\Rightarrow$ &
     \describetile{man9}{9 man}{kyuuwan} &
-    $\rightarrow$\\[2ex]
+    $\rightarrow$ &
+    \tile{man1}\\[2ex]
 
-  % winds
-    $\hookrightarrow$ &
+    % winds
     \describetile{ton}{East}{ton} &
     $\rightarrow$ &
     \describetile{nan}{South}{nan} &
@@ -75,19 +74,20 @@
     $\rightarrow$ &
     \describetile{pei}{North}{pei} &
     $\rightarrow$ &
+    \tile{ton} &
 
-% legend
+    % legend
     \multicolumn{3}{c}{%
       \fbox{\pbox{3em}{\normalsize$\Rightarrow$ seqs. \& dora\\$\rightarrow$ dora only}}%
     } &
 
     % dragons
-    $\hookrightarrow$ &
     \describetile{haku}{White}{haku} &
     $\rightarrow$ &
     \describetile{hatsu}{Green}{hatsu} &
     $\rightarrow$ &
     \describetile{chun}{Red}{chun} &
-    $\rightarrow$
+    $\rightarrow$ &
+    \tile{haku}
   \end{tabular}
 \end{center}


### PR DESCRIPTION
Duplicating the first tile prevents the interpretation that the next tile in the dora sequence after the 9 is the 1 of the suit below.

Thanks @petzku.